### PR TITLE
Remove EAG '15 polaroid

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,17 +224,6 @@
                 <div class="polaroid-note polaroid-note-right">That's my photo being burned in effigy</div>
             </div>
 
-            <!-- Polaroid 4 -->
-            <div class="polaroid-with-note">
-                <div class="polaroid" style="transform:rotate(2deg)">
-                    <div class="polaroid-img">
-                        <img src="images/eag-google.jpg" alt="EAG '15">
-                    </div>
-                    <div class="polaroid-caption">EAG '15</div>
-                </div>
-                <div class="polaroid-note polaroid-note-right">hosted it at Google — my first significant foray into EA</div>
-            </div>
-
             <!-- ASCII art -->
             <div class="dossier-ascii">
    ,--.


### PR DESCRIPTION
## Summary
- Removes the EAG '15 polaroid (and its hover note) from the dossier section on index.html

## Test plan
- [ ] Load index.html locally and confirm the EAG '15 polaroid no longer renders
- [ ] Confirm surrounding polaroids (FAR.Labs, TI4, Motel California) still display correctly
- [ ] Check mobile layout at <600px breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)